### PR TITLE
Add toCssString method to main Color class

### DIFF
--- a/lib/cielab_color.dart
+++ b/lib/cielab_color.dart
@@ -51,6 +51,7 @@ class CielabColor extends Color {
   CielabColor toCielabColor() => this;
 
   String toString() => "l: $l, a: $a, b: $b";
+  String toCssString() => toRgbColor().toCssString();
 
   Map<String, num> toMap() => {'l': l, 'a': a, 'b': b};
 

--- a/lib/color.dart
+++ b/lib/color.dart
@@ -43,6 +43,7 @@ abstract class Color {
   XyzColor toXyzColor();
   CielabColor toCielabColor();
 
+  String toCssString();
   String toString();
   Map<String, num> toMap();
 

--- a/lib/xyz_color.dart
+++ b/lib/xyz_color.dart
@@ -75,6 +75,8 @@ class XyzColor extends Color {
     return new CielabColor(lab['l'], lab['a'], lab['b']);
   }
 
+  String toCssString() => toRgbColor().toCssString();
+
   String toString() => "x: $x, y: $y, z: $z";
 
   Map<String, num> toMap() => {'x': x, 'y': y, 'z': z};


### PR DESCRIPTION
Adds the toCssString method to the Color class so it's no longer neccessary to know the color model to convert it to a css string.