### PR TITLE
fix type problems when compiling with DDC

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -8,5 +8,6 @@
 <body>
 
 <script src="demo.dart" type="application/dart"></script>
+<script src="/packages/browser/dart.js"></script>
 </body>
 </html>

--- a/lib/color_filter.dart
+++ b/lib/color_filter.dart
@@ -11,7 +11,8 @@ class ColorFilter {
   /**
    * Makes the color lighter by the percentage specified in the first argument, or by 10% if no percentage is specified. Percentages should be specified as a float, e.g. an argument of 0.25 will result in a color 25% lighter than the original. The lightening conversion is performed by adjusting the y component of the color in XYZ color space.
    */
-  static ColorFilter lighten = new ColorFilter((CielabColor color, [List args]) {
+  static ColorFilter lighten = new ColorFilter((Color inputColor, [List args]) {
+    CielabColor color = inputColor.toCielabColor();
     num percent = 0.1;
     if (args is List && args.length > 0 && args[0] is num) {
       percent = args[0];
@@ -22,7 +23,8 @@ class ColorFilter {
   /**
    * Makes the color darker by the percentage specified in the first argument, or by 10% if no percentage is specified. Percentages should be specified as a float, e.g. an argument of 0.25 will result in a color 25% darker than the original. The darkening conversion is performed by adjusting the y component of the color in XYZ color space.
    */
-  static ColorFilter darken = new ColorFilter((CielabColor color, [List args]) {
+  static ColorFilter darken = new ColorFilter((Color inputColor, [List args]) {
+    CielabColor color = inputColor.toCielabColor();
     num percent = 0.1;
     if (args is List && args.length > 0 && args[0] is num) {
       percent = args[0];
@@ -33,24 +35,27 @@ class ColorFilter {
   /**
    * Converts the color into its sepia tone equivalent.
    */
-  static ColorFilter sepia = new ColorFilter((RgbColor color, [List args]) {
+  static ColorFilter sepia = new ColorFilter((Color baseColor, [List args]) {
+    RgbColor color = baseColor.toRgbColor();
     return new RgbColor(min(RgbColor.rMax, (color.r * 0.393 + color.g * 0.769 + color.b * 0.189)),
         min(RgbColor.gMax, (color.r * 0.349 + color.g * 0.686 + color.b * 0.168)),
-        min(RgbColor.bMax, (color.r * 0.272 + color.g * 0.534 + color.b * 0.131)));
+        min(RgbColor.bMax, (color.r * 0.272 + color.g * 0.534 + color.b * 0.131))).toCielabColor();
   }, RgbColor);
 
   /**
    * Creates a greyscale color with the same perceived luminance as the source color (as given by the L* value of the color in the CieLAB color space).
    */
-  static ColorFilter greyscale = new ColorFilter((CielabColor color, [List args]) {
+  static ColorFilter greyscale = new ColorFilter((Color inputColor, [List args]) {
+    CielabColor color = inputColor.toCielabColor();
     num rgbLevel = color.l * 255 / 100;
-    return new RgbColor(rgbLevel, rgbLevel, rgbLevel);
+    return new RgbColor(rgbLevel, rgbLevel, rgbLevel).toCielabColor();
   }, CielabColor);
 
   /**
    * Inverts the color by flipping it along the red/green, blue/yellow, and light/dark axes.
    */
-  static ColorFilter invert = new ColorFilter((CielabColor color, [List args]) {
+  static ColorFilter invert = new ColorFilter((Color inputColor, [List args]) {
+    CielabColor color = inputColor.toCielabColor();
     return new CielabColor(100 - color.l, -1 * color.a, -1 * color.b);
   }, CielabColor);
 


### PR DESCRIPTION
# Overview
There are type errors when trying to compile with the Dart Development Compiler (DDC). 

# Solution
Fix the dynamic-ish filter functions to convert to the correct types that are expected. They will have already been converted with the _convert function, but this makes the compiler happy.

# Testing
 - Use Dart >= 1.24.0 with DDC
 - `pub serve --web-compiler=dartdevc demo`
 - load localhost:8080 with regular Chrome, not Dartium. It should load the demo page.