### PR TITLE
HashCode Improvements

### DIFF
--- a/lib/cielab_color.dart
+++ b/lib/cielab_color.dart
@@ -12,6 +12,9 @@ class CielabColor extends Color {
     return xyz.toRgbColor();
   }
 
+  @override
+  int get hashCode => _hash3(l, a, b);
+
   HslColor toHslColor() => this.toRgbColor().toHslColor();
 
   XyzColor toXyzColor() {

--- a/lib/color.dart
+++ b/lib/color.dart
@@ -17,6 +17,7 @@ part 'cielab_color.dart';
 part 'color_filter.dart';
 part 'css_color_space.dart';
 part 'color_parser.dart';
+part 'hash.dart';
 
 /**
  * An object representing a color.
@@ -41,11 +42,6 @@ abstract class Color {
 
   String toString();
   Map<String, num> toMap();
-
-  get hashCode {
-    RgbColor rgb = this.toRgbColor();
-    return 256 * 256 * rgb.r.toInt() + 256 * rgb.g.toInt() + rgb.b.toInt();
-  }
 
   operator ==(Object other) => other is Color && this.hashCode == other.hashCode;
 

--- a/lib/hash.dart
+++ b/lib/hash.dart
@@ -1,0 +1,19 @@
+part of color;
+
+/// Generates a hash code for three objects.
+int _hash3(num a, num b, num c) => _finish(
+    _combine(_combine(_combine(0, a.hashCode), b.hashCode), c.hashCode));
+
+// Jenkins hash functions
+
+int _combine(int hash, int value) {
+  hash = 0x1fffffff & (hash + value);
+  hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+  return hash ^ (hash >> 6);
+}
+
+int _finish(int hash) {
+  hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+  hash = hash ^ (hash >> 11);
+  return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+}

--- a/lib/hsl_color.dart
+++ b/lib/hsl_color.dart
@@ -25,6 +25,9 @@ class HslColor extends Color implements CssColorSpace {
    */
   const HslColor(num this.h, num this.s, num this.l);
 
+  @override
+  int get hashCode => _hash3(h, s, l);
+
   RgbColor toRgbColor() {
     List<num> rgb = [0, 0, 0];
 

--- a/lib/rgb_color.dart
+++ b/lib/rgb_color.dart
@@ -30,6 +30,9 @@ class RgbColor extends Color implements CssColorSpace {
     }
   }
 
+  @override
+  int get hashCode => _hash3(r, g, b);
+
   RgbColor toRgbColor() => this;
 
   HslColor toHslColor() {

--- a/lib/xyz_color.dart
+++ b/lib/xyz_color.dart
@@ -9,6 +9,9 @@ class XyzColor extends Color {
 
   const XyzColor(num this.x, num this.y, num this.z);
 
+  @override
+  int get hashCode => _hash3(x, y, z);
+
   RgbColor toRgbColor() {
     num x = this.x / 100;
     num y = this.y / 100;


### PR DESCRIPTION
Currently, the hashCode implementation for `Color` and all its subclasses does a `.toRgbColor()` and hashes the result. This pattern is not optimal as it requires an object allocation anytime hashCode is called.

In this pr I am proposing each color kind implements their own hashCode as a jenkins hash of the given color's fields. The jenkins hash function is a copy of [quiver's hash function](https://pub.dev/documentation/quiver/latest/quiver.core/hash3.html). I opted to just copy this rather from quiver than introduce a dependency.

